### PR TITLE
Fix a Numpy Warning Caused By an Empty Matrix

### DIFF
--- a/contextualbandits/offpolicy.py
+++ b/contextualbandits/offpolicy.py
@@ -347,7 +347,8 @@ class OffsetTree:
         y_node[r_more_onehalf] = 1. - y[r_more_onehalf]
         w_node = (.5 - r_node) / p_node
         w_node[r_more_onehalf] = (  (r_node - .5) / p_node  )[r_more_onehalf]
-        w_node = w_node * (w_node.shape[0] / np.sum(w_node))
+        if w_node.shape[0] != 0:
+            w_node = w_node * (w_node.shape[0] / np.sum(w_node))
         
         n_pos = y_node.sum()
         if y_node.shape[0] == 0:


### PR DESCRIPTION
When the `w_node` matrix is empty, `numpy` gives the following warning:

```
RuntimeWarning: invalid value encountered in double_scalars
```

Therefore, I added the check. If the matrix is empty, then we don't need to update `w_node`.