### PR TITLE
remove an assertion for the reward estimator

### DIFF
--- a/contextualbandits/offpolicy.py
+++ b/contextualbandits/offpolicy.py
@@ -130,7 +130,6 @@ class DoublyRobustEstimator:
         
         if type(reward_estimator) == np.ndarray:
             assert reward_estimator.shape[1] == nchoices
-            assert reward_estimator.shape[0] == X.shape[0]
         else:
             assert ('predict_proba_separate' in dir(reward_estimator)) or ('predict_proba' in dir(reward_estimator))
 


### PR DESCRIPTION
The variable `X` was not defined in the scope. How about removing or commenting the assertion?

```python
assert reward_estimator.shape[0] == X.shape[0]
```