### PR TITLE
Add output_all_scores parameter to predict() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Documentation is also internally available through docstrings (e.g. you can try 
 
 ## Recent additions
 
-* Added `output_all_scores` parameter to `predict()` method - returns the full score matrix used for making predictions. This is particularly useful for Thompson Sampling and other stochastic methods where calling `decision_function()` multiple times produces different results due to randomness.
+* Added `output_all_scores` parameter to `predict()` method of some online policies, which returns the full score matrix that was used for the choices of arms made during the same `.predict()` call.
 * Can now pass per-arm smoothing and beta_prior hyperparameters.
 * Can now work with sparse matrices in CSR format.
 * Added functionality for ranking top-N arms instead of always picking the single best one.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Documentation is also internally available through docstrings (e.g. you can try 
 
 ## Recent additions
 
+* Added `output_all_scores` parameter to `predict()` method - returns the full score matrix used for making predictions. This is particularly useful for Thompson Sampling and other stochastic methods where calling `decision_function()` multiple times produces different results due to randomness.
 * Can now pass per-arm smoothing and beta_prior hyperparameters.
 * Can now work with sparse matrices in CSR format.
 * Added functionality for ranking top-N arms instead of always picking the single best one.

--- a/contextualbandits/online.py
+++ b/contextualbandits/online.py
@@ -583,7 +583,7 @@ class _BasePolicyWithExploit(_BasePolicy):
             Whether to output the score that this method predicted, in case it is desired to use
             it with this package's offpolicy and evaluation modules.
         output_all_scores : bool
-            Whether to output the scores for all arms/choices. If True, the returned
+            Whether to output the scores for all arms/choices. If 'True', the returned
             dictionary will include a 'scores' key containing the full score matrix
             (n_samples, n_choices). These are the actual scores computed and used to
             make the prediction. This is particularly useful for Thompson Sampling and

--- a/contextualbandits/online.py
+++ b/contextualbandits/online.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np, warnings, ctypes
-from .utils import _check_constructor_input, _check_beta_prior, _check_beta_prior_single, \
+from .utils import _BootstrappedClassifierBase, _check_constructor_input, _check_beta_prior, _check_beta_prior_single, \
             _check_smoothing, _check_fit_input, _check_X_input, \
             _OneVsRest,\
             _BootstrappedClassifier_w_predict, _BootstrappedClassifier_w_predict_proba, \
@@ -2355,6 +2355,7 @@ class ExploreFirst(_ActivePolicy):
             
             # case 2: some predictions are within allowance, others are not
             else:
+                n_explore = self.explore_rounds - self.explore_cnt + X.shape[0]
                 scores = np.empty((X.shape[0], self.nchoices), dtype = ctypes.c_double)
                 scores[:n_explore] = self.random_state.random(size=(n_explore, self.nchoices))
                 self._choose_active(X[:n_explore], scores[:n_explore], choose=False)

--- a/contextualbandits/online.py
+++ b/contextualbandits/online.py
@@ -599,13 +599,6 @@ class _BasePolicyWithExploit(_BasePolicy):
             - 'scores' : array (n_samples, n_choices) - Scores for all arms
                          (only when output_all_scores=True)
 
-        Notes
-        -----
-        The scores matrix is computed only once per prediction call, which is critical
-        for stochastic methods like Thompson Sampling. If you need scores for all arms
-        along with predictions, use output_all_scores=True rather than calling
-        decision_function() separately, as separate calls may produce different scores
-        due to stochasticity.
         """
         if not self.is_fitted:
             return self._predict_random_if_unfit(X, output_score, output_all_scores)

--- a/contextualbandits/online.py
+++ b/contextualbandits/online.py
@@ -585,10 +585,8 @@ class _BasePolicyWithExploit(_BasePolicy):
         output_all_scores : bool
             Whether to output the scores for all arms/choices. If 'True', the returned
             dictionary will include a 'scores' key containing the full score matrix
-            (n_samples, n_choices). These are the actual scores computed and used to
-            make the prediction. This is particularly useful for Thompson Sampling and
-            other stochastic methods where calling decision_function() multiple times
-            produces different results. When True, implies output_score=True.
+            (n_samples, n_choices). These are the scores that were calculated for each arm
+            and from which the choice of action in 'choice' was made according to the policy.
 
         Returns
         -------


### PR DESCRIPTION
## Summary

- Adds `output_all_scores` parameter to the `predict()` method in `_BasePolicyWithExploit` class
- When `output_all_scores=True`, returns the full score matrix (n_samples, n_choices) that was used to make predictions
- Updates `_predict_random_if_unfit()` to also support the new parameter
- Documents the change in README.md

## Motivation

For Thompson Sampling and other stochastic methods, calling `decision_function()` multiple times produces different results due to randomness. When users need both the predictions and the underlying scores, calling `predict()` followed by `decision_function()` produces inconsistent results since the scores that informed the prediction are different from the scores returned by the separate `decision_function()` call.

This PR allows users to get the actual scores that were computed and used for making the prediction in a single call.

## Usage

```python
result = policy.predict(X, output_all_scores=True)
# result["choice"] - the chosen arms
# result["score"] - the score of each chosen arm
# result["scores"] - the full score matrix (n_samples, n_choices)
```